### PR TITLE
Organize Ceph and RGW Zabbix checks

### DIFF
--- a/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
+++ b/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>2.0</version>
-    <date>2015-06-10T21:11:39Z</date>
+    <date>2015-07-22T19:49:26Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -18,6 +18,9 @@
             </groups>
             <applications>
                 <application>
+                    <name>Ceph</name>
+                </application>
+                <application>
                     <name>Functional Checks</name>
                 </application>
                 <application>
@@ -25,6 +28,49 @@
                 </application>
             </applications>
             <items>
+                <item>
+                    <name>Ceph Health</name>
+                    <type>0</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>ceph.health</key>
+                    <delay>90</delay>
+                    <history>3</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>4</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Ceph</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
                 <item>
                     <name>Ceph PG Count: Active</name>
                     <type>7</type>
@@ -66,6 +112,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Ceph PG Count: Active+Clean</name>
@@ -108,6 +155,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Ceph PG Count: Active+Degraded</name>
@@ -150,6 +198,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Ceph PG Count: Active+Remapped</name>
@@ -192,6 +241,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Ceph PG Count: Down</name>
@@ -234,6 +284,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Ceph PG Count: Inactive</name>
@@ -276,6 +327,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Ceph Total Objects</name>
@@ -318,6 +370,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Ceph Total Percent</name>
@@ -360,6 +413,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Ceph Total Space</name>
@@ -402,6 +456,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Ceph Total Usage</name>
@@ -444,6 +499,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Functional Test: Nova</name>
@@ -486,6 +542,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Functional Test: Rados Gateway</name>
@@ -528,6 +585,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Apache</name>
@@ -570,6 +628,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Ceph MDS</name>
@@ -612,6 +671,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Ceph MON</name>
@@ -654,6 +714,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Cinder API</name>
@@ -696,6 +757,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Cinder Scheduler</name>
@@ -738,6 +800,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Cinder Volume</name>
@@ -780,6 +843,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Glance API</name>
@@ -822,6 +886,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Glance Registry</name>
@@ -864,6 +929,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Keystone</name>
@@ -906,6 +972,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: MySQL</name>
@@ -948,6 +1015,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Nova Cert</name>
@@ -990,6 +1058,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Nova Conductor</name>
@@ -1032,6 +1101,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Nova ConsoleAuth</name>
@@ -1074,6 +1144,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Nova Scheduler</name>
@@ -1116,6 +1187,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: PowerDNS</name>
@@ -1158,6 +1230,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: RabbitMQ</name>
@@ -1200,6 +1273,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Aborted Clients</name>
@@ -1242,6 +1316,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Aborted Connections</name>
@@ -1284,6 +1359,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Data In</name>
@@ -1326,6 +1402,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Data Out</name>
@@ -1368,6 +1445,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL New Connections</name>
@@ -1410,6 +1488,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Ping</name>
@@ -1452,6 +1531,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Query Rate</name>
@@ -1494,6 +1574,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Apache</name>
@@ -1536,6 +1617,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Ceph MDS</name>
@@ -1578,6 +1660,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Ceph MON</name>
@@ -1620,6 +1703,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Cinder API</name>
@@ -1662,6 +1746,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Cinder Scheduler</name>
@@ -1704,6 +1789,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Cinder Volume</name>
@@ -1746,6 +1832,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Glance API</name>
@@ -1788,6 +1875,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Glance Registry</name>
@@ -1830,6 +1918,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: HAProxy</name>
@@ -1872,6 +1961,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Keepalived</name>
@@ -1914,6 +2004,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Keystone</name>
@@ -1956,6 +2047,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: MySQL</name>
@@ -1998,6 +2090,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Nova Cert</name>
@@ -2040,6 +2133,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Nova Conductor</name>
@@ -2082,6 +2176,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Nova ConsoleAuth</name>
@@ -2124,6 +2219,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Nova Scheduler</name>
@@ -2166,6 +2262,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: PowerDNS</name>
@@ -2208,6 +2305,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: RabbitMQ</name>
@@ -2250,6 +2348,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>RGW: Number buckets</name>
@@ -2292,6 +2391,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
             </items>
             <discovery_rules>
@@ -2324,132 +2424,6 @@
                     <lifetime>2</lifetime>
                     <description>Creates RGW bucket monitoring tools</description>
                     <item_prototypes>
-                        <item_prototype>
-                            <name>Bucket DELETE ops/s {#BKTNAME}</name>
-                            <type>7</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>ceph.rgw.bucket.usage[{#BKTNAME},delete_obj,ops]</key>
-                            <delay>90</delay>
-                            <history>3</history>
-                            <trends>30</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>1</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>The number of DELETE operations on {#BKTNAME} per sec</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>RGW</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Bucket GET B/s {#BKTNAME}</name>
-                            <type>7</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>ceph.rgw.bucket.usage[{#BKTNAME},put_obj,bytes_sent]</key>
-                            <delay>90</delay>
-                            <history>3</history>
-                            <trends>30</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <delta>1</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Data download rate</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>RGW</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Bucket GET ops/s {#BKTNAME}</name>
-                            <type>7</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>ceph.rgw.bucket.usage[{#BKTNAME},get_obj,ops]</key>
-                            <delay>90</delay>
-                            <history>3</history>
-                            <trends>30</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>1</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>The number of GET operations on {#BKTNAME} per sec</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>RGW</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                        </item_prototype>
                         <item_prototype>
                             <name>Bucket Objects {#BKTNAME}</name>
                             <type>7</type>
@@ -2491,48 +2465,7 @@
                                 </application>
                             </applications>
                             <valuemap/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Bucket PUT ops/s {#BKTNAME}</name>
-                            <type>7</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>ceph.rgw.bucket.usage[{#BKTNAME},put_obj,ops]</key>
-                            <delay>90</delay>
-                            <history>3</history>
-                            <trends>30</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>1</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>The number of put operations on {#BKTNAME} per sec</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>RGW</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
+                            <logtimefmt/>
                         </item_prototype>
                         <item_prototype>
                             <name>Bucket Size {#BKTNAME}</name>
@@ -2575,6 +2508,7 @@
                                 </application>
                             </applications>
                             <valuemap/>
+                            <logtimefmt/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes/>
@@ -2645,6 +2579,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Carbon Cache</name>
@@ -2687,6 +2622,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Carbon Relay</name>
@@ -2729,6 +2665,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Diamond</name>
@@ -2771,6 +2708,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Elasticsearch</name>
@@ -2813,6 +2751,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Fluentd</name>
@@ -2855,6 +2794,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Kibana</name>
@@ -2897,6 +2837,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: MySQL</name>
@@ -2939,6 +2880,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Aborted Clients</name>
@@ -2981,6 +2923,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Aborted Connections</name>
@@ -3023,6 +2966,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Data In</name>
@@ -3065,6 +3009,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Data Out</name>
@@ -3107,6 +3052,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL New Connections</name>
@@ -3149,6 +3095,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Ping</name>
@@ -3191,6 +3138,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>MySQL Query Rate</name>
@@ -3233,6 +3181,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Apache</name>
@@ -3275,6 +3224,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Carbon Cache</name>
@@ -3317,6 +3267,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Carbon Relay</name>
@@ -3359,6 +3310,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Diamond</name>
@@ -3401,6 +3353,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Elasticsearch</name>
@@ -3443,6 +3396,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Fluentd</name>
@@ -3485,6 +3439,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: HAProxy</name>
@@ -3527,6 +3482,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Keepalived</name>
@@ -3569,6 +3525,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Kibana</name>
@@ -3611,6 +3568,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: MySQL</name>
@@ -3653,6 +3611,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: SSHd</name>
@@ -3695,6 +3654,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
             </items>
             <discovery_rules/>
@@ -3716,55 +3676,10 @@
             </groups>
             <applications>
                 <application>
-                    <name>Ceph</name>
-                </application>
-                <application>
                     <name>RGW</name>
                 </application>
             </applications>
             <items>
-                <item>
-                    <name>Ceph Health</name>
-                    <type>7</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>ceph.health</key>
-                    <delay>90</delay>
-                    <history>3</history>
-                    <trends>30</trends>
-                    <status>0</status>
-                    <value_type>4</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>Ceph</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                </item>
                 <item>
                     <name>IP Route: MGMT</name>
                     <type>7</type>
@@ -3806,6 +3721,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>IP Route: Storage</name>
@@ -3848,6 +3764,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Ceph OSD</name>
@@ -3890,6 +3807,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Diamond</name>
@@ -3932,6 +3850,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Fluentd</name>
@@ -3974,6 +3893,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Nova API</name>
@@ -4016,6 +3936,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Nova Compute</name>
@@ -4058,6 +3979,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Nova Network</name>
@@ -4100,6 +4022,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Memory check: Nova NoVNCProxy</name>
@@ -4142,6 +4065,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Ceph OSD</name>
@@ -4184,6 +4108,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Diamond</name>
@@ -4226,6 +4151,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Fluentd</name>
@@ -4268,6 +4194,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Nova API</name>
@@ -4310,6 +4237,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Nova Compute</name>
@@ -4352,6 +4280,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Nova Network</name>
@@ -4394,6 +4323,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: Nova NoVNCProxy</name>
@@ -4436,6 +4366,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: NTPd</name>
@@ -4478,6 +4409,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>Process check: SSHd</name>
@@ -4520,90 +4452,7 @@
                         </application>
                     </applications>
                     <valuemap/>
-                </item>
-                <item>
-                    <name>RGW: admin access /m</name>
-                    <type>7</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>ceph.rgw.admin</key>
-                    <delay>90</delay>
-                    <history>3</history>
-                    <trends>30</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>RGW</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                </item>
-                <item>
-                    <name>RGW: Errors</name>
-                    <type>7</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>log[/var/log/apache2/rgw_error.log]</key>
-                    <delay>90</delay>
-                    <history>3</history>
-                    <trends>30</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>RGW</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>RGW: HAProxy Pings / m</name>
@@ -4646,6 +4495,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
                 <item>
                     <name>RGW: HTTP 500 Errors / m</name>
@@ -4688,6 +4538,7 @@
                         </application>
                     </applications>
                     <valuemap/>
+                    <logtimefmt/>
                 </item>
             </items>
             <discovery_rules/>
@@ -4742,7 +4593,7 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{BCPC-Worknode:ceph.health.str(HEALTH_ERROR,#1)}=1</expression>
+            <expression>{BCPC-Headnode:ceph.health.str(HEALTH_ERROR,#1)}=1</expression>
             <name>Ceph Health Error</name>
             <url/>
             <status>0</status>
@@ -4752,7 +4603,7 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{BCPC-Worknode:ceph.health.str(HEALTH_WARN,#1)}=1</expression>
+            <expression>{BCPC-Headnode:ceph.health.str(HEALTH_WARN,#1)}=1</expression>
             <name>Ceph Health Warn</name>
             <url/>
             <status>0</status>

--- a/cookbooks/bcpc/recipes/zabbix-agent.rb
+++ b/cookbooks/bcpc/recipes/zabbix-agent.rb
@@ -82,6 +82,18 @@ if node['bcpc']['enabled']['monitoring'] then
         notifies :restart, "service[zabbix-agent]", :immediately
     end
 
+    template "/etc/zabbix/zabbix_agentd.d/zabbix-rgw.conf" do
+        source "zabbix_rgw.conf.erb"
+        owner node['bcpc']['zabbix']['user']
+        group "root"
+        mode 00600
+        variables(
+            :rgw_frontend => node['bcpc']['ceph']['frontend']
+        )
+        only_if 'test -f /usr/bin/radosgw'
+        notifies :restart, "service[zabbix-agent]", :immediately
+    end
+
     template "/etc/zabbix/zabbix_agentd.d/userparameter_mysql.conf" do
         source "zabbix_agentd_userparameters_mysql.conf.erb"
         owner node['bcpc']['zabbix']['user']

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -61,7 +61,9 @@
     # For Apache
     rgw socket path = /var/lib/ceph/radosgw/rgw_fcgi.sock
 <% end %>
-    debug rgw = 0/0
+    # Increased to 1 to log HTTP return codes
+    # http://tracker.ceph.com/issues/12432
+    debug rgw = 1/0
 
 <% if config_defined('keystone-admin-token') %>
     rgw keystone url = <%=node['bcpc']['management']['vip']%>:35358

--- a/cookbooks/bcpc/templates/default/zabbix_openstack.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_openstack.conf.erb
@@ -11,14 +11,3 @@ UserParameter=ceph.pool.objects[*],HOME=/var/lib/zabbix rados df | egrep "^$1 " 
 UserParameter=ceph.total.usage[*],HOME=/var/lib/zabbix rados df | egrep "total used" | awk '{}{print $$3}' | tr -d '\n'
 UserParameter=ceph.total.space[*],HOME=/var/lib/zabbix rados df | egrep "total space" | awk '{}{print $$3}' | tr -d '\n'
 UserParameter=ceph.total.objects[*],HOME=/var/lib/zabbix rados df | egrep "total used" | awk '{}{print $$4}' | tr -d '\n'
-UserParameter=ceph.rgw.nbuckets[*],HOME=/var/lib/zabbix radosgw-admin bucket list | python -c "import json, sys; print len(json.load(sys.stdin));"
-UserParameter=ceph.rgw.bucket.size[*],HOME=/var/lib/zabbix radosgw-admin bucket stats --bucket='$1' | python -c "import json, sys; print 1024*(json.load(sys.stdin)['usage']['rgw.main']['size_kb'])"
-UserParameter=ceph.rgw.bucket.objects[*],HOME=/var/lib/zabbix radosgw-admin bucket stats --bucket='$1' | python -c "import json, sys; print json.load(sys.stdin)['usage']['rgw.main']['num_objects']"
-UserParameter=ceph.rgw.bucket.usage[*],HOME=/var/lib/zabbix  /usr/local/bin/zabbix_bucket_stats $1 $2 | egrep '^$3 ' | awk '{}{print $$2}'
-UserParameter=ceph.rgw.bucket.discovery,HOME=/var/lib/zabbix /usr/local/bin/zabbix_discover_buckets
-UserParameter=ceph.rgw.haproxy[*],HOME=/var/lib/zabbix logtail -o /tmp/rgw_haproxy -f   /var/log/apache2/rgw_access.log | grep '"GET / HTTP/1.0" 200 ' | wc -l
-UserParameter=ceph.rgw.http500[*],HOME=/var/lib/zabbix logtail -o /tmp/rgw_500 -f   /var/log/apache2/rgw_access.log | egrep 'HTTP\/1\.[0-9]" 500 ' | wc -l 
-UserParameter=ceph.rgw.admin[*],HOME=/var/lib/zabbix logtail -o /tmp/rgw_admin -f   /var/log/apache2/rgw_access.log | grep '" /admin/' | wc -l 
-UserParameter=ceph.rgw.bucket.puts[*],HOME=/var/lib/zabbix logtail -o /tmp/rgw_puts -f   /var/log/apache2/rgw_access.log | grep '"PUT /$1' | wc -l 
-UserParameter=ceph.rgw.bucket.gets[*],HOME=/var/lib/zabbix logtail -o /tmp/rgw_gets -f   /var/log/apache2/rgw_access.log | grep '"GET /$1' | wc -l 
-UserParameter=ceph.rgw.bucket.deletes[*],HOME=/var/lib/zabbix logtail -o /tmp/rgw_dels -f   /var/log/apache2/rgw_access.log | grep '"DELETE /$1' | wc -l 

--- a/cookbooks/bcpc/templates/default/zabbix_rgw.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_rgw.conf.erb
@@ -1,0 +1,13 @@
+UserParameter=ceph.rgw.nbuckets[*],HOME=/var/lib/zabbix radosgw-admin bucket list | python -c "import json, sys; print len(json.load(sys.stdin));"
+UserParameter=ceph.rgw.bucket.size[*],HOME=/var/lib/zabbix radosgw-admin bucket stats --bucket='$1' | python -c "import json, sys; print 1024*(json.load(sys.stdin)['usage']['rgw.main']['size_kb'])"
+UserParameter=ceph.rgw.bucket.objects[*],HOME=/var/lib/zabbix radosgw-admin bucket stats --bucket='$1' | python -c "import json, sys; print json.load(sys.stdin)['usage']['rgw.main']['num_objects']"
+UserParameter=ceph.rgw.bucket.usage[*],HOME=/var/lib/zabbix  /usr/local/bin/zabbix_bucket_stats $1 $2 | egrep '^$3 ' | awk '{}{print $$2}'
+UserParameter=ceph.rgw.bucket.discovery,HOME=/var/lib/zabbix /usr/local/bin/zabbix_discover_buckets
+<% if @rgw_frontend.include? 'civetweb' %>
+UserParameter=ceph.rgw.haproxy[*],HOME=/var/lib/zabbix logtail -o /tmp/civetweb_rgw_haproxy -f /var/log/ceph/radosgw.log | grep -B 1 '"GET / HTTP/1.0"' | grep http_status=200 | wc -l
+UserParameter=ceph.rgw.http500[*],HOME=/var/lib/zabbix logtail -o /tmp/civetweb_rgw_500 -f /var/log/ceph/radosgw.log | egrep 'http_status=50[0-9]' | wc -l
+<% else %>
+UserParameter=ceph.rgw.haproxy[*],HOME=/var/lib/zabbix logtail -o /tmp/apache_rgw_haproxy -f   /var/log/apache2/rgw_access.log | grep '"GET / HTTP/1.0" 200 ' | wc -l
+UserParameter=ceph.rgw.http500[*],HOME=/var/lib/zabbix logtail -o /tmp/aache_rgw_500 -f /var/log/apache2/rgw_access.log | egrep 'HTTP\/1\.[0-9]" 500 ' | wc -l
+<% end %>
+


### PR DESCRIPTION
The following changes are introduced with this PR:
1. Increase RGW logging so HTTP return codes are appropriately logged. This will be in place until http://tracker.ceph.com/issues/12432 is resolved.
2. Monitor Civetweb logs if it's the RGW frontend in use.
3. Monitor `ceph health` on head nodes only.
4. Remove unnecessary Zabbix items (i.e. HTTP metrics) as these are better suited to be counted and presented in Kibana/Graphite.

In Zabbix [2.2.6](http://www.zabbix.com/rn2.2.6.php), `logtimefmt` field is added to all exported items. Since `zabbix_bcpc_templates.xml` was generated while we were on 2.2.2, the field addition is expected and can be safely ignored.

For the updated Zabbix templates to take effect on a running cluster, one needs to drop `BCPC-Headnode` and `BCPC-Worknode` templates (ensuring `delete selected with linked elements` is checked), then re-associate hosts with the appropriate templates. This is clearly not ideal. I am increasingly tempted to upgrade Zabbix to [2.4](https://www.zabbix.com/documentation/2.4/manual/introduction/whatsnew240#option_to_remove_missing_resources_when_importing) to address this shortcoming. Something for another PR.