### PR TITLE
Run Zabbix API requests against local instance

### DIFF
--- a/cookbooks/bcpc/recipes/zabbix-server.rb
+++ b/cookbooks/bcpc/recipes/zabbix-server.rb
@@ -185,7 +185,7 @@ if node['bcpc']['enabled']['monitoring'] then
         code <<-EOH
              a2ensite zabbix-web
         EOH
-        not_if "test -r /etc/apache2/sites-enabled/zabbix-web"
+        not_if "test -r /etc/apache2/sites-enabled/zabbix-web.conf"
         notifies :restart, "service[apache2]", :immediate
     end
 
@@ -221,8 +221,8 @@ if node['bcpc']['enabled']['monitoring'] then
     ruby_block "configure_zabbix_templates" do
         block do
             # Ensures no proxy is ever used locally
-            %x[export no_proxy="#{node['bcpc']['management']['monitoring']['vip']}";
-               zabbix_config https://#{node['bcpc']['management']['monitoring']['vip']}/zabbix #{get_config('zabbix-admin-user')} #{get_config('zabbix-admin-password')}
+            %x[export no_proxy="#{node['bcpc']['management']['ip']}";
+               zabbix_config http://#{node['bcpc']['management']['ip']}:7777/ #{get_config('zabbix-admin-user')} #{get_config('zabbix-admin-password')}
             ]
         end
     end
@@ -237,7 +237,7 @@ if node['bcpc']['enabled']['monitoring'] then
     ruby_block "zabbix-api-auto-discovery-register" do
         block do
             # Ensures no proxy is ever used locally
-            %x[export no_proxy="#{node['bcpc']['management']['monitoring']['vip']}";
+            %x[export no_proxy="#{node['bcpc']['management']['ip']}";
                /usr/share/zabbix/zabbix-api-auto-discovery
             ]
         end

--- a/cookbooks/bcpc/templates/default/zabbix_api_auto_discovery.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_api_auto_discovery.erb
@@ -5,6 +5,7 @@ import json
 
 headers = {'content-type': 'application/json'}
 roles = ['BCPC-Headnode', 'BCPC-Worknode', 'BCPC-Monitoring']
+zabbix_url = 'http://<%= node['bcpc']['management']['ip'] %>:7777/api_jsonrpc.php'
 
 login_api = {
     "jsonrpc": "2.0", "method": "user.login",
@@ -14,7 +15,7 @@ login_api = {
     },
     "id": 1 }
 
-status = requests.post("https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/api_jsonrpc.php", data=json.dumps(login_api), verify=False, headers=headers)
+status = requests.post(zabbix_url, data=json.dumps(login_api), verify=False, headers=headers)
 api_login = status.json()['result']
 
 for role in roles:
@@ -28,7 +29,7 @@ for role in roles:
         "auth": api_login,
         "id": 1 }
 
-    status = requests.post("https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/api_jsonrpc.php", data=json.dumps(exists_api), verify=False, headers=headers)
+    status = requests.post(zabbix_url, data=json.dumps(exists_api), verify=False, headers=headers)
 
     if not status.json()['result']:
         # Determine if template exists
@@ -45,7 +46,7 @@ for role in roles:
             "auth": api_login,
             "id": 1
         }
-        response = requests.post("https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/api_jsonrpc.php", data=json.dumps(template_api), verify=False, headers=headers)
+        response = requests.post(zabbix_url, data=json.dumps(template_api), verify=False, headers=headers)
         if not response.json()['result']:
             raise Exception("Missing template: " + role)
         templateid = response.json()['result'][0]['templateid']
@@ -64,7 +65,7 @@ for role in roles:
             "auth": api_login,
             "id": 1
         }
-        response = requests.post("https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/api_jsonrpc.php", data=json.dumps(hostgroup_api), verify=False, headers=headers)
+        response = requests.post(zabbix_url, data=json.dumps(hostgroup_api), verify=False, headers=headers)
         if not response.json()['result']:
             raise Exception("Missing hostgroup: " + role)
         hostgroupid = response.json()['result'][0]['groupid']
@@ -107,7 +108,7 @@ for role in roles:
             "id": 1
         }
 
-        status = requests.post("https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/api_jsonrpc.php", data=json.dumps(create_api), verify=False, headers=headers)
+        status = requests.post(zabbix_url, data=json.dumps(create_api), verify=False, headers=headers)
         if not status.json()['result']:
             raise Exception("Unable to create discovery action: " + role)
 
@@ -123,7 +124,7 @@ for drule in <%=node['bcpc']['zabbix']['discovery']['ip_ranges']%>:
         "id": 1
     }
 
-    response = requests.post("https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/api_jsonrpc.php", data=json.dumps(drule_exists_api), verify=False, headers=headers)
+    response = requests.post(zabbix_url, data=json.dumps(drule_exists_api), verify=False, headers=headers)
     if not response.json()['result']:
         drule_create_api = {
             "jsonrpc": "2.0",
@@ -144,7 +145,7 @@ for drule in <%=node['bcpc']['zabbix']['discovery']['ip_ranges']%>:
             "auth": api_login,
             "id": 1
         }
-        status = requests.post("https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/api_jsonrpc.php", data=json.dumps(drule_create_api), verify=False, headers=headers)
+        status = requests.post(zabbix_url, data=json.dumps(drule_create_api), verify=False, headers=headers)
         if not status.json()['result']:
             raise Exception("Unable to create discovery rule: " + drule)
 


### PR DESCRIPTION
`zabbix_config` and `zabbix-api-auto-discovery` in `zabbix-server.rb` sometimes fail to complete successfully on first monitoring node's Chef-run due to delayed apache and haproxy instantiation of zabbix site. This tends to have noticeable impact if you are only bootstrapping one monitoring node.

I have tested this on a fresh build (one monitoring node) and verified that the following are true:
1. `BCPC-Headnode`, `BCPC-Worknode` and `BCPC-Monitoring` templates exist in https://10.0.100.6/zabbix/templates.php.
2. Discovery rule `10.0.100.0/24` is in https://10.0.100.6/zabbix/discoveryconf.php.
3. bcpc-vm* VMs are associated with appropriate templates in https://10.0.100.6/zabbix/hosts.php.