### PR TITLE
Enable Zabbix alert scripts path

### DIFF
--- a/cookbooks/bcpc/templates/default/zabbix_server.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_server.conf.erb
@@ -389,7 +389,7 @@ ListenIP=<%=node['bcpc']['management']['monitoring']['vip']%>
 #
 # Mandatory: no
 # Default:
-# AlertScriptsPath=${datadir}/zabbix/alertscripts
+AlertScriptsPath=/usr/lib/zabbix/alertscripts
 
 ### Option: ExternalScripts
 #   Full path to location of external scripts.


### PR DESCRIPTION
No-op change. Enable the path where alert scripts are placed for [custom alerting](https://www.zabbix.com/documentation/2.2/manual/config/notifications/media/script).