### PR TITLE
Glance API version 2 upgrade

### DIFF
--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -182,7 +182,7 @@ bash "glance-cirros-image" do
     code <<-EOH
         . /root/adminrc
         qemu-img convert -f qcow2 -O raw /tmp/cirros-0.3.4-x86_64-disk.img /tmp/cirros-0.3.4-x86_64-disk.raw
-        glance image-create --name='Cirros 0.3.4 x86_64' --is-public=True --container-format=bare --disk-format=raw --file /tmp/cirros-0.3.4-x86_64-disk.raw
+        glance image-create --name='Cirros 0.3.4 x86_64' --visibility=public --container-format=bare --disk-format=raw --file /tmp/cirros-0.3.4-x86_64-disk.raw
     EOH
     not_if ". /root/adminrc; glance image-list | grep 'Cirros 0.3.4 x86_64'"
 end

--- a/cookbooks/bcpc/templates/default/adminrc.erb
+++ b/cookbooks/bcpc/templates/default/adminrc.erb
@@ -11,3 +11,5 @@ export OS_AUTH_URL=<%=node['bcpc']['protocol']['keystone']%>://openstack.<%=node
 export OS_REGION_NAME=<%=@node['bcpc']['region_name']%>
 export OS_NO_CACHE=1
 export OS_CACERT=/etc/ssl/certs/ssl-bcpc.pem
+# both Glance API versions are enabled but prefer v2
+export OS_IMAGE_API_VERSION=2

--- a/cookbooks/bcpc/templates/default/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder.conf.erb
@@ -33,7 +33,7 @@ osapi_volume_workers=1
 # Other service endpoints
 glance_api_servers=<%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292
 glance_api_insecure=True
-glance_api_version=1
+glance_api_version=2
 
 # Volume driver settings for RBD
 enabled_backends=<%= node['bcpc']['ceph']['enabled_pools'].map {|type| type.upcase}.join(",") %>

--- a/cookbooks/bcpc/templates/default/index.html.erb
+++ b/cookbooks/bcpc/templates/default/index.html.erb
@@ -88,7 +88,7 @@
 			</div>
 			<div class="block">
 				<label>Glance API</label>
-				<a href="<%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1"><%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1</a>
+				<a href="<%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1"><%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v2</a>
 			</div>
 			<div class="block">
 				<label>Cinder API</label>

--- a/cookbooks/bcpc/templates/default/keystone-default_catalog.templates.erb
+++ b/cookbooks/bcpc/templates/default/keystone-default_catalog.templates.erb
@@ -14,9 +14,9 @@ catalog.<%=node['bcpc']['region_name']%>.object-store.adminURL = http://openstac
 catalog.<%=node['bcpc']['region_name']%>.object-store.internalURL = http://openstack.<%=node['bcpc']['cluster_domain']%>/swift/v1
 catalog.<%=node['bcpc']['region_name']%>.object-store.name = Object Store Service
 
-catalog.<%=node['bcpc']['region_name']%>.image.publicURL = <%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292/v1
-catalog.<%=node['bcpc']['region_name']%>.image.adminURL = <%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292/v1
-catalog.<%=node['bcpc']['region_name']%>.image.internalURL = <%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292/v1
+catalog.<%=node['bcpc']['region_name']%>.image.publicURL = <%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292/v2
+catalog.<%=node['bcpc']['region_name']%>.image.adminURL = <%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292/v2
+catalog.<%=node['bcpc']['region_name']%>.image.internalURL = <%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292/v2
 catalog.<%=node['bcpc']['region_name']%>.image.name = Image Service
 
 catalog.<%=node['bcpc']['region_name']%>.compute.publicURL = <%=node['bcpc']['protocol']['nova']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8774/v1.1/$(tenant_id)s


### PR DESCRIPTION
This PR supersedes #742 and should be tested in the same fashion.

* update service catalog to v2 URL
* update Cinder to use v2
* no change to Nova, which apparently does not care or even have an explicit way to set the API version
* does NOT update Horizon to use v2, because Horizon does not support Glance API v2 (see https://blueprints.launchpad.net/horizon/+spec/horizon-glance-v2)

**Test strategy:**

* create volumes from images using `cinder create --image-id` and via Horizon
* launch instances using **Boot from image (creates a new volume)**
* verify that RAW image to volume clone operations are happening entirely in Ceph and are not going via the API (QCOW2 image to volume clones will still need to go through the API and be converted, and `cinder create` from a QCOW2 image may result in something unusable)
  * if things are working you will see basically no activity on the node where the Cinder API is running
  * if things are not working you will see high `glance-api` and `haproxy` CPU usage because the image is being piped through the API
  * check `rbd ls -l volumes-ssd` to verify that volumes created are COW snapshots of the image (the volumes will show the image as their parent if COW)
* do various volume operations (create, delete, resize, etc.)