### PR TITLE
Added support for AZs in compute

### DIFF
--- a/cookbooks/bcpc/recipes/host-aggregates.rb
+++ b/cookbooks/bcpc/recipes/host-aggregates.rb
@@ -16,8 +16,12 @@
 # limitations under the License.
 #
 
-az_number = (node['hostname'] =~ /bcpc\-vm/) ? node['bcpc']['node_number'] : node['bcpc']['rack']
-availability_zone = (node['bcpc']['availability_zone'].nil? ) ? node['bcpc']['region_name'] + "-" + az_number : node['bcpc']['availability_zone']
+az_number = if node['hostname'] =~ /bcpc\-vm/
+  node['bcpc']['node_number']
+else
+  node['bcpc']['rack'].nil? ? 1 : node['bcpc']['rack']
+end 
+availability_zone = (node['bcpc']['availability_zone'].nil? ) ? node['bcpc']['region_name'] + "-" + az_number.to_s : node['bcpc']['availability_zone'].to_s
 
 node['bcpc']['host_aggregates'].each do |name, properties| 
   bcpc_host_aggregate name do

--- a/cookbooks/bcpc/recipes/host-aggregates.rb
+++ b/cookbooks/bcpc/recipes/host-aggregates.rb
@@ -16,6 +16,9 @@
 # limitations under the License.
 #
 
+az_number = (node['hostname'] =~ /bcpc\-vm/) ? node['bcpc']['node_number'] : node['bcpc']['rack']
+availability_zone = (node['bcpc']['availability_zone'].nil? ) ? node['bcpc']['region_name'] + "-" + az_number : node['bcpc']['availability_zone']
+
 node['bcpc']['host_aggregates'].each do |name, properties| 
   bcpc_host_aggregate name do
     metadata properties
@@ -25,7 +28,15 @@ end
 node['bcpc']['aggregate_membership'].each do |name| 
     bcpc_host_aggregate name do
         action :member 
-        zone  node['bcpc']['region_name']
     end
 end 
+
+bcpc_host_aggregate availability_zone do
+  action :create
+  zone availability_zone
+end
+
+bcpc_host_aggregate availability_zone do
+  action :member
+end
 

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -67,7 +67,7 @@ send_arp_for_ha=True
 my_ip=<%=node['bcpc']['management']['ip']%>
 routing_source_ip=<%=node['bcpc']['floating']['ip']%>
 dhcp_domain=<%=node['bcpc']['cluster_domain']%>
-default_availability_zone=<%=node['bcpc']['region_name']%>
+default_availability_zone=
 
 # Nova Compute settings
 compute_driver=libvirt.LibvirtDriver


### PR DESCRIPTION
Currently users can use server groups to make sure they don't land on the same host. If however, you have a bigger failure domain, e.g. racks, there is no way to allow users to spread VMs over these. 

This PR introduces availability zones (AZ). By default the AZ will be one per rack, however, you can create your own AZ by setting `node['bcpc']['availability_zone']`.

In the laptop environment we give each node its own AZ, just for fun. 
