### PR TITLE
reconciling fluentd gems between the build_bins scripts

### DIFF
--- a/cookbooks/bcpc/files/default/build_bins.sh
+++ b/cookbooks/bcpc/files/default/build_bins.sh
@@ -146,22 +146,16 @@ if [ ! -f kibana_${VER_KIBANA}_amd64.deb ]; then
 fi
 FILES="kibana_${VER_KIBANA}_amd64.deb $FILES"
 
-# any pegged gem versions
-REV_elasticsearch="0.9.0"
-
+GEMS=( excon-0.45.3
+       multi_json-1.11.2 multipart-post-2.0.0 faraday-0.9.1
+       elasticsearch-api-1.0.12 elasticsearch-transport-1.0.12
+       elasticsearch-1.0.12 fluent-plugin-elasticsearch-0.9.0 )
 # Grab plugins for fluentd
-for i in elasticsearch; do
-    if [ ! -f fluent-plugin-${i}.gem ]; then
-        PEG=REV_${i}
-        if [[ ! -z ${!PEG} ]]; then
-            VERS="-v ${!PEG}"
-        else
-            VERS=""
-        fi
-        gem fetch $GEM_PROXY fluent-plugin-${i} ${VERS}
-        mv fluent-plugin-${i}-*.gem fluent-plugin-${i}.gem
+for GEM in ${GEMS[@]}; do
+    if [ ! -f $GEM.gem ]; then
+        ccurl https://rubygems.global.ssl.fastly.net/gems/$GEM.gem
     fi
-    FILES="fluent-plugin-${i}.gem $FILES"
+    FILES="$GEM.gem $FILES"
 done
 
 # Fetch the cirros image for testing

--- a/cookbooks/bcpc/recipes/fluentd.rb
+++ b/cookbooks/bcpc/recipes/fluentd.rb
@@ -53,43 +53,29 @@ if node['bcpc']['enabled']['logging'] then
         action :upgrade
     end
 
-    if node['bcpc']['use_bootstrap_v2']
-      fluentd_gems = %w{
-        excon-0.45.3
-        multi_json-1.11.2
-        multipart-post-2.0.0
-        faraday-0.9.1
-        elasticsearch-transport-1.0.12
-        elasticsearch-api-1.0.12
-        elasticsearch-1.0.12
-        fluent-plugin-elasticsearch-0.9.0
-      }
-    
-      fluentd_gems.each do |pkg|
-        cookbook_file "/tmp/#{pkg}.gem" do
-          source "bins/#{pkg}.gem"
-          owner "root"
-          mode 00444
-        end
+    fluentd_gems = %w{
+      excon-0.45.3
+      multi_json-1.11.2
+      multipart-post-2.0.0
+      faraday-0.9.1
+      elasticsearch-transport-1.0.12
+      elasticsearch-api-1.0.12
+      elasticsearch-1.0.12
+      fluent-plugin-elasticsearch-0.9.0
+    }
+  
+    fluentd_gems.each do |pkg|
+      cookbook_file "/tmp/#{pkg}.gem" do
+        source "bins/#{pkg}.gem"
+        owner "root"
+        mode 00444
+      end
 
-        bash "install-#{pkg}" do
-          code "/opt/td-agent/embedded/bin/fluent-gem install --local --no-ri --no-rdoc /tmp/#{pkg}.gem"
-          not_if "/opt/td-agent/embedded/bin/fluent-gem list --local --no-versions | grep #{pkg}$"
-        end
+      bash "install-#{pkg}" do
+        code "/opt/td-agent/embedded/bin/fluent-gem install --local --no-ri --no-rdoc /tmp/#{pkg}.gem"
+        not_if "/opt/td-agent/embedded/bin/fluent-gem list --local --no-versions | grep #{pkg}$"
       end
-    else
-      %w{elasticsearch}.each do |pkg|
-          cookbook_file "/tmp/fluent-plugin-#{pkg}.gem" do
-              source "bins/fluent-plugin-#{pkg}.gem"
-              owner "root"
-              mode 00444
-          end
-          bash "install-fluent-plugin-#{pkg}" do
-              code "/opt/td-agent/embedded/bin/fluent-gem install --local --no-ri --no-rdoc /tmp/fluent-plugin-#{pkg}.gem"
-              not_if "/opt/td-agent/embedded/bin/fluent-gem list --local --no-versions | grep fluent-plugin-#{pkg}$"
-          end
-      end
-    end # if node['bcpc']['use_bootstrap_v2']
+    end
 
     template "/etc/td-agent/td-agent.conf" do
         source "fluentd-td-agent.conf.erb"


### PR DESCRIPTION
This should fix an issue reported by @mihalis68 where some gems were not made available to the non-Vagrant build path. 