### PR TITLE
Parameterize worker counts for Glance, Cinder and Heat

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -979,6 +979,7 @@ default['bcpc']['nova']['policy'] = {
 #  Cinder Settings
 #
 ###########################################
+default['bcpc']['cinder']['workers'] = 5
 default['bcpc']['cinder']['quota'] = {
   "volumes" => 10,
   "quota_snapshots" => 10,
@@ -1083,6 +1084,7 @@ default['bcpc']['cinder']['policy'] = {
 #  Glance policy Settings
 #
 ###########################################
+default['bcpc']['glance']['workers'] = 5
 default['bcpc']['glance']['policy'] = {
   "context_is_admin" => "role:admin",
   "default" => "",
@@ -1149,6 +1151,7 @@ default['bcpc']['glance']['policy'] = {
 #  Heat policy Settings
 #
 ###########################################
+default['bcpc']['heat']['workers'] = 5
 default['bcpc']['heat']['policy'] = {
   "deny_stack_user" => "not role:heat_stack_user",
   "deny_everybody" => "!",

--- a/cookbooks/bcpc/recipes/mysql-head.rb
+++ b/cookbooks/bcpc/recipes/mysql-head.rb
@@ -58,7 +58,7 @@ template "/etc/mysql/debian.cnf" do
 end
 
 if node['bcpc']['mysql-head']['max_connections'] == 0 then
-    node.default['bcpc']['mysql-head']['max_connections'] = [get_head_nodes.length*100+get_all_nodes.length*10, 200].max
+    node.default['bcpc']['mysql-head']['max_connections'] = [get_head_nodes.length*150+get_all_nodes.length*10, 200].max
 end
 
 template "/etc/mysql/conf.d/wsrep.cnf" do

--- a/cookbooks/bcpc/templates/default/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder.conf.erb
@@ -22,7 +22,7 @@ enable_v2_api=true
 
 # Bind to mgt IP only
 osapi_volume_listen=<%=node['bcpc']['management']['ip']%>
-osapi_volume_workers=1
+osapi_volume_workers=<%= node['bcpc']['cinder']['workers'] %>
 
 # If using qpid...
 #rpc_backend=cinder.openstack.common.rpc.impl_qpid

--- a/cookbooks/bcpc/templates/default/glance-api.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-api.conf.erb
@@ -16,7 +16,7 @@ log_file = /var/log/glance/api.log
 backlog = 4096
 #tcp_keepidle = 600
 # data_api = glance.db.sqlalchemy.api
-workers = 1
+workers = <%= node['bcpc']['glance']['workers'] %>
 # max_header_line = 16384
 admin_role = <%=node['bcpc']['admin_role']%>
 #allow_anonymous_access = False

--- a/cookbooks/bcpc/templates/default/heat.conf.erb
+++ b/cookbooks/bcpc/templates/default/heat.conf.erb
@@ -865,7 +865,7 @@ bind_host=<%= node['bcpc']['management']['ip'] %>
 #key_file=<None>
 
 # Number of workers for Heat service. (integer value)
-#workers=0
+workers=<%= node['bcpc']['heat']['workers'] %>
 
 # Maximum line size of message headers to be accepted.
 # max_header_line may need to be increased when using large
@@ -900,7 +900,7 @@ bind_host=<%= node['bcpc']['management']['ip'] %>
 #key_file=<None>
 
 # Number of workers for Heat service. (integer value)
-#workers=0
+workers=<%= node['bcpc']['heat']['workers'] %>
 
 # Maximum line size of message headers to be accepted.
 # max_header_line may need to be increased when using large
@@ -935,7 +935,7 @@ bind_host=<%= node['bcpc']['management']['ip'] %>
 #key_file=<None>
 
 # Number of workers for Heat service. (integer value)
-#workers=0
+workers=<%= node['bcpc']['heat']['workers'] %>
 
 # Maximum line size of message headers to be accepted.
 # max_header_line may need to be increased when using large


### PR DESCRIPTION
The worker counts for Glance/Cinder were fixed at 1, and Heat was creating as many workers as CPU cores times 3. This parameterizes all worker counts (and also adjusts the default MySQL connection count calculation upwards a bit, because MySQL connections are cheap).