### PR TITLE
Rework the landing page in several ways

### DIFF
--- a/cookbooks/bcpc/templates/default/index.html.erb
+++ b/cookbooks/bcpc/templates/default/index.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" xml:lang="en">
 	<head>
 		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-		<title><%=node['bcpc']['region_name']%> - <%=node['bcpc']['management']['vip']%> - BCPC</title>
+		<title><%= node['bcpc']['region_name'] %> - <%= node['bcpc']['management']['vip'] %> - BCPC</title>
 	</head>
 	<body>
 		<style>
@@ -26,97 +26,117 @@
 				margin-left:4px;
 				float:left;
 			}
+			table {
+			    border: 1px solid black;
+			    border-spacing: 0px;
+			}
+			th {
+			    border: 1px solid black;
+			    padding: 4px;
+			}
+			td {
+			    border: 1px solid black;
+			    padding: 4px;
+			}
 		</style>
 
-		<h2><%=node['bcpc']['region_name']%> - <%=node['bcpc']['management']['vip']%></h2>
-		<p class="version">BCPC cookbook <%= @cookbook_version %> (<%=node['bcpc']['openstack_release']%>-<%=node['bcpc']['openstack_branch']%>)</p>
+		<h2><%= node['bcpc']['region_name'] %> - openstack.<%= node['bcpc']['cluster_domain'] %> (<%= node['bcpc']['management']['vip'] %>)</h2>
+		<p class="version">BCPC cookbook <%= @cookbook_version %> (<%= node['bcpc']['openstack_release'] %>-<%= node['bcpc']['openstack_branch'] %>)</p>
 		
 		<h3>Web Interfaces</h3>
-			<div class="block">
-				<label>Openstack</label>
-				<a href="https://openstack.<%=node['bcpc']['cluster_domain']%>/horizon">https://openstack.<%=node['bcpc']['cluster_domain']%>/horizon</a>
-				<br/><label>-</label>
-				<a href="https://<%=node['bcpc']['management']['vip']%>/horizon">https://<%=node['bcpc']['management']['vip']%>/horizon</a>
-			</div>
-			<div class="block">
-				<label>HAProxy</label>
-				<a href="https://openstack.<%=node['bcpc']['cluster_domain']%>/haproxy">https://openstack.<%=node['bcpc']['cluster_domain']%>/haproxy</a>
-				<br/><label>-</label>
-				<a href="https://<%=node['bcpc']['management']['vip']%>/haproxy">https://<%=node['bcpc']['management']['vip']%>/haproxy</a>
-			</div>
-			<div class="block">
-				<label>PHP-LDAP-Admin</label>
-				<a href="https://<%=node['bcpc']['management']['vip']%>/phpldapadmin/">https://<%=node['bcpc']['management']['vip']%>/phpldapadmin/</a>
-			</div>
-			<div class="block">
-				<label>RabbitMQ</label>
-				<a href="https://<%=node['bcpc']['management']['vip']%>/rabbitmq/">https://<%=node['bcpc']['management']['vip']%>/rabbitmq/</a>
-			</div>
-			<div class="block">
-				<label>ElasticSearch</label>
-				<a href="http://<%=node['bcpc']['management']['monitoring']['vip']%>:9200/_plugin/head/">http://<%=node['bcpc']['management']['monitoring']['vip']%>:9200/_plugin/head/</a>
-			</div>
-			<div class="block">
-				<label>Kibana</label>
-				<a href="https://<%=node['bcpc']['kibana']['fqdn']%>">https://<%=node['bcpc']['kibana']['fqdn']%></a>
-				<br/><label>-</label>
-				<a href="https://<%=node['bcpc']['management']['monitoring']['vip']%>/kibana/">https://<%=node['bcpc']['management']['monitoring']['vip']%>/kibana/</a>
-			</div>
-			<div class="block">
-				<label>Graphite</label>
-				<a href="https://<%=node['bcpc']['graphite']['fqdn']%>">https://<%=node['bcpc']['graphite']['fqdn']%></a>
-				<br/><label>-</label>
-				<a href="https://<%=node['bcpc']['management']['monitoring']['vip']%>:8888">https://<%=node['bcpc']['management']['monitoring']['vip']%>:8888</a>
-			</div>
-			<div class="block">
-				<label>Zabbix</label>
-				<a href="https://<%=node['bcpc']['zabbix']['fqdn']%>">https://<%=node['bcpc']['zabbix']['fqdn']%></a>
-				<br/><label>-</label>
-				<a href="https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/">https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/</a>
-			</div>
+        <table>
+            <tr>
+                <th>Resource</th>
+                <th>URL</th>
+                <th>IP-based URL (deprecated)</th>
+            </tr>
+            <tr>
+                <td><em>OpenStack<em></td>
+                <td><a href="https://openstack.<%= node['bcpc']['cluster_domain'] %>/horizon">https://openstack.<%= node['bcpc']['cluster_domain'] %>/horizon</a></td>
+                <td><a href="https://<%= node['bcpc']['management']['vip'] %>/horizon">https://<%= node['bcpc']['management']['vip'] %>/horizon</a></td>
+            </tr>
+            <tr>
+                <td><em>HAProxy</em></td>
+                <td><a href="https://openstack.<%= node['bcpc']['cluster_domain'] %>/haproxy">https://openstack.<%= node['bcpc']['cluster_domain'] %>/haproxy</a></td>
+                <td><a href="https://<%= node['bcpc']['management']['vip'] %>/haproxy">https://<%= node['bcpc']['management']['vip'] %>/haproxy</a></td>
+            </tr>
+            <tr>
+                <td><em>RabbitMQ</em></td>
+                <td><a href="https://openstack.<%= node['bcpc']['cluster_domain'] %>/rabbitmq/">https://openstack.<%= node['bcpc']['cluster_domain'] %>/rabbitmq/</a></td>
+                <td><a href="https://<%= node['bcpc']['management']['vip'] %>/rabbitmq/">https://<%= node['bcpc']['management']['vip'] %>/rabbitmq/</a></td>
+            </tr>
+            <tr>
+                <td><em>Elasticsearch</em></td>
+                <td>---</td>
+                <td><a href="http://<%= node['bcpc']['management']['monitoring']['vip'] %>:9200/_plugin/head/">http://<%= node['bcpc']['management']['monitoring']['vip'] %>:9200/_plugin/head/</a></td>
+            </tr>
+            <tr>
+                <td><em>Kibana</em></td>
+                <td><a href="https://<%= node['bcpc']['kibana']['fqdn'] %>">https://<%= node['bcpc']['kibana']['fqdn'] %></a></td>
+                <td><a href="https://<%= node['bcpc']['management']['monitoring']['vip'] %>/kibana/">https://<%= node['bcpc']['management']['monitoring']['vip'] %>/kibana/</a></td>
+            </tr>
+            <tr>
+                <td><em>Graphite</em></td>
+                <td><a href="https://<%= node['bcpc']['graphite']['fqdn'] %>">https://<%= node['bcpc']['graphite']['fqdn'] %></a></td>    
+                <td><a href="https://<%= node['bcpc']['management']['monitoring']['vip'] %>:8888">https://<%= node['bcpc']['management']['monitoring']['vip'] %>:8888</a></td>
+            </tr>
+            <tr>
+                <td><em>Zabbix</em></td>
+                <td><a href="https://<%= node['bcpc']['zabbix']['fqdn'] %>">https://<%= node['bcpc']['zabbix']['fqdn'] %></a></td>
+                <td><a href="https://<%= node['bcpc']['management']['monitoring']['vip'] %>/zabbix/">https://<%= node['bcpc']['management']['monitoring']['vip'] %>/zabbix/</a></td>
+        </table>
 
 		<h3>API Endpoints</h3>
-			<div class="block">
-				<label>Keystone API</label>
-				<a href="<%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['cluster_domain']%>:5000/v2.0"><%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['cluster_domain']%>:5000/v2.0</a>
-				<br/><label>-</label>
-				<a href="<%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['management']['vip']%>:5000/v2.0"><%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['management']['vip']%>:5000/v2.0</a>
-			</div>
-			<div class="block">
-				<label>Keystone Admin API</label>
-				<a href="<%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['cluster_domain']%>:35357/v2.0"><%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['cluster_domain']%>:35357/v2.0</a>
-				<br/><label>-</label>
-				<a href="<%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['management']['vip']%>:35357/v2.0"><%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['management']['vip']%>:35357/v2.0</a>
-			</div>
-			<div class="block">
-				<label>Nova API</label>
-				<a href="<%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['cluster_domain']%>:8774/v1.1"><%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['cluster_domain']%>:8774/v1.1</a>
-				<br/><label>-</label>
-				<a href="<%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8774/v1.1"><%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8774/v1.1</a>
-			</div>
-			<div class="block">
-				<label>Glance API</label>
-				<a href="<%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['cluster_domain']%>:9292/v1"><%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['cluster_domain']%>:9292/v2</a>
-				<br/><label>-</label>
-				<a href="<%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1"><%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v2</a>
-			</div>
-			<div class="block">
-				<label>Cinder API</label>
-				<a href="<%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['cluster_domain']%>:8776/v1"><%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['cluster_domain']%>:8776/v1</a>
-				<br/><label>-</label>
-				<a href="<%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['management']['vip']%>:8776/v1"><%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['management']['vip']%>:8776/v1</a>
-			</div>
-			<div class="block">
-				<label>EC2 API</label>
-				<a href="<%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['cluster_domain']%>:8773/services/Cloud"><%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['cluster_domain']%>:8773/services/Cloud</a>
-				<br/><label>-</label>
-				<a href="<%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8773/services/Cloud"><%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8773/services/Cloud</a>
-			</div>
+		<em>While other API versions may be available for a given endpoint, only the ones listed here are supported for tenant use. Unlisted API versions may change or go away without notice.</em>
+		<br/>
+		<table>
+		    <tr>
+		        <th>Resource</th>
+		        <th>URL</th>
+		        <th>IP-based URL (deprecated)</th>
+		    <tr>
+		    <tr>
+		        <td><em>Keystone API</em></td>
+		        <td><a href="<%= node['bcpc']['protocol']['keystone'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:5000/v2.0"><%= node['bcpc']['protocol']['keystone'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:5000/v2.0</a></td>
+		        <td><a href="<%= node['bcpc']['protocol']['keystone'] %>://<%= node['bcpc']['management']['vip'] %>:5000/v2.0"><%= node['bcpc']['protocol']['keystone'] %>://<%= node['bcpc']['management']['vip'] %>:5000/v2.0</a></td>
+		    </tr>
+		    <tr>
+		        <td><em>Keystone Admin API</em></td>
+		        <td><a href="<%= node['bcpc']['protocol']['keystone'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:35357/v2.0"><%= node['bcpc']['protocol']['keystone'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:35357/v2.0</a></td>
+		        <td><a href="<%= node['bcpc']['protocol']['keystone'] %>://<%= node['bcpc']['management']['vip'] %>:35357/v2.0"><%= node['bcpc']['protocol']['keystone'] %>://<%= node['bcpc']['management']['vip'] %>:35357/v2.0</a></td>
+		    </tr>
+            <tr>
+                <td><em>Nova API</em></td>
+                <td><a href="<%= node['bcpc']['protocol']['nova'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:8774/v1.1"><%= node['bcpc']['protocol']['nova'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:8774/v1.1</a></td>
+                <td><a href="<%= node['bcpc']['protocol']['nova'] %>://<%= node['bcpc']['management']['vip'] %>:8774/v1.1"><%= node['bcpc']['protocol']['nova'] %>://<%= node['bcpc']['management']['vip'] %>:8774/v1.1</a></td>
+            </tr>
+            <tr>
+                <td><em>Glance API</em></td>
+                <td><a href="<%= node['bcpc']['protocol']['glance'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:9292/v2"><%= node['bcpc']['protocol']['glance'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:9292/v2</a></td>
+                <td><a href="<%= node['bcpc']['protocol']['glance'] %>://<%= node['bcpc']['management']['vip'] %>:9292/v2"><%= node['bcpc']['protocol']['glance'] %>://<%= node['bcpc']['management']['vip'] %>:9292/v2</a></td>
+            </tr>
+            <tr>
+                <td><em>Cinder API</em></td>
+                <td><a href="<%= node['bcpc']['protocol']['cinder'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:8776/v1"><%= node['bcpc']['protocol']['cinder'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:8776/v1</a></td>
+                <td><a href="<%= node['bcpc']['protocol']['cinder'] %>://<%= node['bcpc']['management']['vip'] %>:8776/v1"><%= node['bcpc']['protocol']['cinder'] %>://<%= node['bcpc']['management']['vip'] %>:8776/v1</a></td>
+            </tr>
+            <tr>
+                <td><em>EC2 API</em></td>
+                <td><a href="<%= node['bcpc']['protocol']['nova'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:8773/services/Cloud"><%= node['bcpc']['protocol']['nova'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:8773/services/Cloud</a></td>
+                <td><a href="<%= node['bcpc']['protocol']['nova'] %>://<%= node['bcpc']['management']['vip'] %>:8773/services/Cloud"><%= node['bcpc']['protocol']['nova'] %>://<%= node['bcpc']['management']['vip'] %>:8773/services/Cloud</a></td>
+            </tr>
+		</table>
 
 		<h3>SSL Certificate</h3>
-			<code>
-				<%=get_config('ssl-certificate').gsub(/\n/, '<br/>')%>
-			</code>
-
+        <code>
+            <%= get_config('ssl-certificate').gsub(/\n/, '<br/>') %>
+        </code>
+        
+        <% if node['bcpc']['ssl_intermediate_certificate'] %>
+        <h3>SSL CA certificate</h3>
+        <code>
+            <%= get_config('ssl-intermediate-certificate').gsub(/\n/, '<br/>') %>
+        </code>
+        <% end %>
 	</body>
 </html>


### PR DESCRIPTION
**Bugfixes**:
- fixes Glance API URL to actually be v2 in the href
- fixes API FQDN URLs to have `openstack.` at the beginning

**Feature additions**:
- print FQDN at top of page next to IP
- move content into tables
- remove PHPLDAPAdmin listing
- add warning about other API versions not being supported
- print SSL intermediate CA cert if there is one
